### PR TITLE
Relax array type contracts by removing readonly requirements across resolver APIs

### DIFF
--- a/.changeset/wet-points-cough.md
+++ b/.changeset/wet-points-cough.md
@@ -1,0 +1,5 @@
+---
+"yassa": patch
+---
+
+Remove readonly attributes for the contracts

--- a/.changeset/wet-points-cough.md
+++ b/.changeset/wet-points-cough.md
@@ -2,4 +2,15 @@
 "yassa": patch
 ---
 
-Remove readonly attributes for the contracts
+Relax array type contracts by removing `readonly` requirements across resolver APIs.
+
+### What changed
+
+- `LocalIgnoredEnvironments` now accepts `string[]` instead of `readonly string[]`.
+- Chain resolvers now return mutable arrays (`string[]`) instead of readonly arrays.
+- Related internal helper typings were aligned to the same mutable array contracts.
+
+### Impact
+
+- Runtime behavior is unchanged.
+- Type ergonomics are improved for consumers who work with mutable arrays.

--- a/README.md
+++ b/README.md
@@ -164,26 +164,26 @@ const chain = await resolveTestChain(".env", ["test"]);
 
 ### `resolveConfigChain(file, localIgnoredEnvironments?)`
 
-- Type: `(file: string, localIgnoredEnvironments?: readonly string[]) => Promise<readonly string[]>`
+- Type: `(file: string, localIgnoredEnvironments?: string[]) => Promise<string[]>`
 - Resolves existing chain for current `NODE_ENV`.
 - Throws if `NODE_ENV` is missing or empty.
 
 ### `resolveConfigChainSync(file, localIgnoredEnvironments?)`
 
-- Type: `(file: string, localIgnoredEnvironments?: readonly string[]) => readonly string[]`
+- Type: `(file: string, localIgnoredEnvironments?: string[]) => string[]`
 - Synchronous counterpart of `resolveConfigChain`.
 - Throws if `NODE_ENV` is missing or empty.
 
 ### `resolveConfigFile(file, localIgnoredEnvironments?)`
 
-- Type: `(file: string, localIgnoredEnvironments?: readonly string[]) => Promise<string | undefined>`
+- Type: `(file: string, localIgnoredEnvironments?: string[]) => Promise<string | undefined>`
 - Returns the top file from `resolveConfigChain`.
 - Returns `undefined` when no candidates exist.
 - Throws if `NODE_ENV` is missing or empty.
 
 ### `resolveConfigFileSync(file, localIgnoredEnvironments?)`
 
-- Type: `(file: string, localIgnoredEnvironments?: readonly string[]) => string | undefined`
+- Type: `(file: string, localIgnoredEnvironments?: string[]) => string | undefined`
 - Synchronous counterpart of `resolveConfigFile`.
 - Throws if `NODE_ENV` is missing or empty.
 
@@ -191,22 +191,22 @@ const chain = await resolveTestChain(".env", ["test"]);
 
 ### `resolveConfigChainFor(environment)`
 
-- Type: `(environment: string) => (file: string, localIgnoredEnvironments?: readonly string[]) => Promise<readonly string[]>`
+- Type: `(environment: string) => (file: string, localIgnoredEnvironments?: string[]) => Promise<string[]>`
 - Curried async factory for environment-bound chain resolution.
 
 ### `resolveConfigChainForSync(environment)`
 
-- Type: `(environment: string) => (file: string, localIgnoredEnvironments?: readonly string[]) => readonly string[]`
+- Type: `(environment: string) => (file: string, localIgnoredEnvironments?: string[]) => string[]`
 - Synchronous counterpart of `resolveConfigChainFor`.
 
 ### `resolveConfigFileFor(environment)`
 
-- Type: `(environment: string) => (file: string, localIgnoredEnvironments?: readonly string[]) => Promise<string | undefined>`
+- Type: `(environment: string) => (file: string, localIgnoredEnvironments?: string[]) => Promise<string | undefined>`
 - Curried async factory for single-file resolution.
 
 ### `resolveConfigFileForSync(environment)`
 
-- Type: `(environment: string) => (file: string, localIgnoredEnvironments?: readonly string[]) => string | undefined`
+- Type: `(environment: string) => (file: string, localIgnoredEnvironments?: string[]) => string | undefined`
 - Synchronous counterpart of `resolveConfigFileFor`.
 
 ## Behavior Details

--- a/src/yassa.ts
+++ b/src/yassa.ts
@@ -17,19 +17,19 @@ import { cwd, env } from "node:process";
  * - `<name>.test<ext>`
  * - `<name><ext>`
  */
-export type LocalIgnoredEnvironments = readonly string[];
+export type LocalIgnoredEnvironments = string[];
 
 /** Returns all existing hierarchy files in precedence order (most specific first). */
 export type ConfigHierarchyFilesResolver = (
 	file: string,
 	localIgnoredEnvironments?: LocalIgnoredEnvironments
-) => Promise<readonly string[]>;
+) => Promise<string[]>;
 
 /** Returns all existing hierarchy files in precedence order (most specific first). */
 export type ConfigHierarchyFilesResolverSync = (
 	file: string,
 	localIgnoredEnvironments?: LocalIgnoredEnvironments
-) => readonly string[];
+) => string[];
 
 /** Returns the most specific existing file (or `undefined`). */
 export type ConfigHierarchyFileResolver = (
@@ -43,7 +43,7 @@ export type ConfigHierarchyFileResolverSync = (
 	localIgnoredEnvironments?: LocalIgnoredEnvironments
 ) => string | undefined;
 
-const EMPTY_LOCAL_IGNORED_ENVIRONMENTS: readonly string[] = [];
+const EMPTY_LOCAL_IGNORED_ENVIRONMENTS: string[] = [];
 const projectRootPathPromise = realpath(cwd());
 const NODE_ENV_MISSING_ERROR =
 	"The NODE_ENV environment variable is required. Set it explicitly or use resolveConfig*For factory functions.";
@@ -76,7 +76,7 @@ const buildHierarchyCandidates = (
 	absoluteBaseFilePath: string,
 	environment: string,
 	localIgnoredEnvironments: LocalIgnoredEnvironments
-): readonly string[] => {
+): string[] => {
 	const basePathObject = parse(absoluteBaseFilePath);
 	const baseFilePath = format(basePathObject);
 	const isLocalIgnored = isLocalIgnoredForEnvironment(environment, localIgnoredEnvironments);
@@ -127,21 +127,21 @@ const canReadFileSync = (filePath: string): boolean => {
 	}
 };
 
-const filterExistingFiles = async (filePaths: readonly string[]): Promise<readonly string[]> => {
+const filterExistingFiles = async (filePaths: string[]): Promise<string[]> => {
 	const readabilityResults = await Promise.all(filePaths.map(filePath => canReadFile(filePath)));
 	return filePaths.filter((_, index) => readabilityResults[index]);
 };
 
-const filterExistingFilesSync = (filePaths: readonly string[]): readonly string[] =>
+const filterExistingFilesSync = (filePaths: string[]): string[] =>
 	filePaths.filter(filePath => canReadFileSync(filePath));
 
-const firstOrUndefined = (filePaths: readonly string[]): string | undefined => filePaths[0];
+const firstOrUndefined = (filePaths: string[]): string | undefined => filePaths[0];
 
 /**
  * Creates an async resolver bound to a specific environment.
  *
  * This is the factory form of the API:
- * `(environment) => (file, localIgnoredEnvironments?) => Promise<readonly string[]>`.
+ * `(environment) => (file, localIgnoredEnvironments?) => Promise<string[]>`.
  *
  * Resolution order (highest precedence first):
  *


### PR DESCRIPTION
### What changed

- `LocalIgnoredEnvironments` now accepts `string[]` instead of `readonly string[]`.
- Chain resolvers now return mutable arrays (`string[]`) instead of readonly arrays.
- Related internal helper typings were aligned to the same mutable array contracts.

### Impact

- Runtime behavior is unchanged.
- Type ergonomics are improved for consumers who work with mutable arrays.
