### PR TITLE
Add non-happy-path coverage for config hierarchy resolution and improve release verification flow

### DIFF
--- a/.changeset/vast-hats-go.md
+++ b/.changeset/vast-hats-go.md
@@ -1,0 +1,5 @@
+---
+"yassa": patch
+---
+
+Add tests for testing not only happy path

--- a/.changeset/vast-hats-go.md
+++ b/.changeset/vast-hats-go.md
@@ -2,4 +2,14 @@
 "yassa": patch
 ---
 
-Add tests for testing not only happy path
+Add non-happy-path coverage for config hierarchy resolution and improve release verification flow.
+
+### What changed
+
+- Added tests to verify that files from unrelated environments are excluded from resolver results.
+- Updated release/backfill automation and release-process documentation to support publication verification.
+
+### Impact
+
+- No changes to the library runtime logic or public API.
+- This release is focused on test coverage and release automation reliability.

--- a/src/yassa.test.ts
+++ b/src/yassa.test.ts
@@ -71,6 +71,43 @@ describe("environment config hierarchy", () => {
 		expect(resolvedFiles).toStrictEqual([envLocalFile, envFile, baseFile]);
 	});
 
+	it("excludes files that belong to other environments", async () => {
+		const baseFile = join(workspacePath, "config", ".env");
+		const developmentFile = join(workspacePath, "config", ".env.development");
+		const developmentLocalFile = join(workspacePath, "config", ".env.development.local");
+		const localFile = join(workspacePath, "config", ".env.local");
+		const productionFile = join(workspacePath, "config", ".env.production");
+		const productionLocalFile = join(workspacePath, "config", ".env.production.local");
+		const stagingFile = join(workspacePath, "config", ".env.staging");
+
+		writeFileWithDirectories(baseFile);
+		writeFileWithDirectories(developmentFile);
+		writeFileWithDirectories(developmentLocalFile);
+		writeFileWithDirectories(localFile);
+		writeFileWithDirectories(productionFile);
+		writeFileWithDirectories(productionLocalFile);
+		writeFileWithDirectories(stagingFile);
+
+		const resolveFiles = resolveConfigChainFor("development");
+		const resolveFilesSync = resolveConfigChainForSync("development");
+		const resolveFile = resolveConfigFileFor("development");
+		const resolveFileSync = resolveConfigFileForSync("development");
+
+		await expect(resolveFiles(baseFile)).resolves.toStrictEqual([
+			developmentLocalFile,
+			localFile,
+			developmentFile,
+			baseFile
+		]);
+		expect(resolveFilesSync(baseFile)).toStrictEqual([developmentLocalFile, localFile, developmentFile, baseFile]);
+		await expect(resolveFile(baseFile)).resolves.toBe(developmentLocalFile);
+		expect(resolveFileSync(baseFile)).toBe(developmentLocalFile);
+
+		await expect(resolveFiles(baseFile)).resolves.not.toContain(productionFile);
+		await expect(resolveFiles(baseFile)).resolves.not.toContain(productionLocalFile);
+		await expect(resolveFiles(baseFile)).resolves.not.toContain(stagingFile);
+	});
+
 	it("supports dotted base file names with extension (for example .env.json)", async () => {
 		const baseFile = join(workspacePath, "config", ".env.json");
 		const envFile = join(workspacePath, "config", ".env.staging.json");


### PR DESCRIPTION
### What changed

- Added tests to verify that files from unrelated environments are excluded from resolver results.
- Updated release/backfill automation and release-process documentation to support publication verification.

### Impact

- No changes to the library runtime logic or public API.
- This release is focused on test coverage and release automation reliability.
