### PR TITLE
Improve release workflow stability and add test coverage for local-ignore behavior

### DIFF
--- a/.changeset/fifty-aliens-learn.md
+++ b/.changeset/fifty-aliens-learn.md
@@ -2,4 +2,14 @@
 "yassa": patch
 ---
 
-Add some more tests
+Improve release workflow stability and add test coverage for local-ignore behavior.
+
+### What changed
+
+- Added a test that verifies `.local` files remain part of the resolved hierarchy when `localIgnoredEnvironments` does not include the active environment.
+- Cleaned up release workflow by removing temporary one-time backfill logic and restoring the standard publish path.
+
+### Impact
+
+- No changes to the library runtime behavior or public API.
+- Improves confidence in expected resolution behavior and release automation reliability.

--- a/.changeset/fifty-aliens-learn.md
+++ b/.changeset/fifty-aliens-learn.md
@@ -1,0 +1,5 @@
+---
+"yassa": patch
+---
+
+Add some more tests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,7 +63,6 @@ jobs:
 
     publish:
         if: >-
-            (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
             github.event_name == 'workflow_dispatch' ||
             (
               github.event_name == 'pull_request_target' &&
@@ -101,82 +100,8 @@ jobs:
 
             - name: Install dependencies
               run: npm ci
-
-            # ===== BEGIN ONE-TIME BACKFILL FOR v1.0.2 (REMOVE AFTER SUCCESSFUL PUBLISH) =====
-            - name: One-time backfill publish + GitHub release for v1.0.2
-              id: backfill-1-0-2
-              if: >-
-                  github.event_name == 'workflow_dispatch' ||
-                  (github.event_name == 'push' && github.ref == 'refs/heads/main')
-              env:
-                  BACKFILL_VERSION: 1.0.2
-                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-              run: |
-                  set -euo pipefail
-
-                  PACKAGE_NAME="$(node -p "require('./package.json').name")"
-                  PACKAGE_VERSION="$(node -p "require('./package.json').version")"
-                  TAG="v${BACKFILL_VERSION}"
-
-                  if [ "${PACKAGE_VERSION}" != "${BACKFILL_VERSION}" ]; then
-                    echo "Skipping backfill: package.json version is ${PACKAGE_VERSION}, expected ${BACKFILL_VERSION}."
-                    echo "skip_changesets=false" >> "$GITHUB_OUTPUT"
-                    exit 0
-                  fi
-
-                  if npm view "${PACKAGE_NAME}@${BACKFILL_VERSION}" version >/dev/null 2>&1; then
-                    echo "npm backfill not required: ${PACKAGE_NAME}@${BACKFILL_VERSION} already published."
-                  else
-                    echo "Publishing missing npm version ${PACKAGE_NAME}@${BACKFILL_VERSION}..."
-                    npm run release:publish
-                  fi
-
-                  if git ls-remote --exit-code --tags origin "refs/tags/${TAG}" >/dev/null 2>&1; then
-                    echo "Git tag ${TAG} already exists on origin."
-                  else
-                    echo "Creating missing git tag ${TAG}..."
-                    git tag "${TAG}" "${GITHUB_SHA}"
-                    git push origin "refs/tags/${TAG}"
-                  fi
-
-                  CHANGELOG_FILE=""
-                  if [ -f "CHANGELOG.md" ]; then
-                    CHANGELOG_FILE="CHANGELOG.md"
-                  elif [ -f "changelog.md" ]; then
-                    CHANGELOG_FILE="changelog.md"
-                  else
-                    echo "::error::Neither CHANGELOG.md nor changelog.md exists."
-                    exit 1
-                  fi
-
-                  NOTES_FILE="/tmp/release-notes-${BACKFILL_VERSION}.md"
-                  awk -v version="${BACKFILL_VERSION}" '
-                    $0 == "## " version { in_version = 1; next }
-                    $0 ~ /^## / && in_version { exit }
-                    in_version { print }
-                  ' "${CHANGELOG_FILE}" > "${NOTES_FILE}"
-
-                  if [ ! -s "${NOTES_FILE}" ]; then
-                    echo "::error::Could not extract release notes for ${BACKFILL_VERSION} from ${CHANGELOG_FILE}."
-                    exit 1
-                  fi
-
-                  if gh release view "${TAG}" >/dev/null 2>&1; then
-                    echo "GitHub release ${TAG} already exists."
-                  else
-                    echo "Creating missing GitHub release ${TAG} from ${CHANGELOG_FILE}..."
-                    gh release create "${TAG}" \
-                      --title "${TAG}" \
-                      --notes-file "${NOTES_FILE}" \
-                      --target "${GITHUB_SHA}"
-                  fi
-
-                  # Backfill handled publish/release for v1.0.2 in this run, so skip default publish step.
-                  echo "skip_changesets=true" >> "$GITHUB_OUTPUT"
-            # ===== END ONE-TIME BACKFILL FOR v1.0.2 (REMOVE AFTER SUCCESSFUL PUBLISH) =====
             - name: Publish via Changesets
               id: changesets
-              if: steps.backfill-1-0-2.outputs.skip_changesets != 'true'
               uses: changesets/action@v1
               with:
                   publish: npm run release:publish

--- a/src/yassa.test.ts
+++ b/src/yassa.test.ts
@@ -206,6 +206,33 @@ describe("environment config hierarchy", () => {
 		await expect(resolveFiles(baseFile, ["test"])).resolves.not.toContain(envLocalFile);
 	});
 
+	it("keeps local files when localIgnoredEnvironments does not include current environment", async () => {
+		const baseFile = join(workspacePath, "config", ".env");
+		const envFile = join(workspacePath, "config", ".env.test");
+		const localFile = join(workspacePath, "config", ".env.local");
+		const envLocalFile = join(workspacePath, "config", ".env.test.local");
+
+		writeFileWithDirectories(baseFile);
+		writeFileWithDirectories(envFile);
+		writeFileWithDirectories(localFile);
+		writeFileWithDirectories(envLocalFile);
+
+		const resolveFiles = resolveConfigChainFor("test");
+		const resolveFilesSync = resolveConfigChainForSync("test");
+		const resolveFile = resolveConfigFileFor("test");
+		const resolveFileSync = resolveConfigFileForSync("test");
+
+		await expect(resolveFiles(baseFile, ["development"])).resolves.toStrictEqual([
+			envLocalFile,
+			localFile,
+			envFile,
+			baseFile
+		]);
+		expect(resolveFilesSync(baseFile, ["development"])).toStrictEqual([envLocalFile, localFile, envFile, baseFile]);
+		await expect(resolveFile(baseFile, ["development"])).resolves.toBe(envLocalFile);
+		expect(resolveFileSync(baseFile, ["development"])).toBe(envLocalFile);
+	});
+
 	it("reads NODE_ENV for resolveConfig* wrappers", async () => {
 		const baseFile = join(workspacePath, "config", ".env");
 		const envFile = join(workspacePath, "config", ".env.development");


### PR DESCRIPTION
### What changed

- Added a test that verifies `.local` files remain part of the resolved hierarchy when `localIgnoredEnvironments` does not include the active environment.
- Cleaned up release workflow by removing temporary one-time backfill logic and restoring the standard publish path.

### Impact

- No changes to the library runtime behavior or public API.
- Improves confidence in expected resolution behavior and release automation reliability.
